### PR TITLE
zj-Add index for images

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -16,4 +16,8 @@ class ImagesController < ApplicationController
   def show
     @image = Image.find(params[:id])
   end
+
+  def index
+    @images = Image.all
+  end
 end

--- a/app/views/application/home.html.erb
+++ b/app/views/application/home.html.erb
@@ -1,3 +1,5 @@
 <h1>Hello world!</h1>
 
-<%= link_to 'Upload image here', new_image_path %>
+<%= link_to 'Upload image here', new_image_path %> <br>
+
+<%= link_to 'View all images', images_path %>

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -1,0 +1,13 @@
+<h1>All Images</h1>
+
+<ul>
+  <% @images.reverse.each do |image| %>
+      <li>
+        <img src="<%= image.link %>" width="400">
+      </li>
+  <% end %>
+</ul>
+
+<p>
+  <%= link_to 'Upload Image', new_image_path %>
+</p>

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -2,3 +2,7 @@
 <p>
   <img src="<%= @image.link %>" >
 </p>
+
+<p>
+  <%= link_to 'Homepage', root_path %>
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  root 'application#home'
-  resources :images, only: [:new, :create, :show]
+  # root 'application#home'
+  root 'images#index'
+  resources :images, only: [:new, :create, :show, :index]
 end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -11,7 +11,45 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
+  def test_index
+    get images_path
+
+    assert_response :ok
+    assert_select 'h1', 'All Images'
+    assert_select 'ul'
+
+    assert_select 'a', 'Upload Image'
+  end
+
+  def test_index_image_order
+    url1 = 'https://i.imgur.com/eMroIPL.jpg'
+    url2 = 'https://i.imgur.com/yKAX9Fm.jpg'
+    url3 = 'https://i.imgur.com/IvVjToQ.jpg'
+    Image.create!(link: url1)
+    Image.create!(link: url2)
+    Image.create!(link: url3)
+
+    get images_path
+    assert_response :ok
+
+    assert_select 'ul'
+    assert_select 'li'
+
+    assert_select 'li:nth-child(1)' do
+      assert_select format('img[src="%<url>s"]', url: url3)
+    end
+
+    assert_select 'li:nth-child(2)' do
+      assert_select format('img[src="%<url>s"]', url: url2)
+    end
+
+    assert_select 'li:nth-child(3)' do
+      assert_select format('img[src="%<url>s"]', url: url1)
+    end
+  end
+
   def test_show
+    @image = Image.create!(link: 'https://i.imgur.com/8GaYYya.jpg')
     get image_path(@image.id)
 
     assert_response :ok


### PR DESCRIPTION
Closes Issue3

Task details:

- [x] New images that are added show up on the homepage.
- [x] These images are persisted if the browser is closed or even if the server is restarted.
- [x] Images are not displayed wider than 400px.
- [x] Newest images appear first.